### PR TITLE
In order to resolve NDEX-405, we need to make sure that all projects use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,23 @@
 			<artifactId>paxtools-core</artifactId>
 			<version>4.2.1</version>
 		</dependency>
-
+		
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+                
 <dependency>
 	<groupId>com.sun.xml.bind</groupId>
 	<artifactId>jaxb-impl</artifactId>


### PR DESCRIPTION
the same version of Jackson library (2.5.2).  So we explicitly add to
the pom file the depenedency of ndex-common from 2.5.2.  Before that,
ndex-common used release 2.3.4.