### PR TITLE
Replaced the "duplicated account name" message with "A user with that

### DIFF
--- a/src/main/java/org/ndexbio/common/models/dao/orientdb/CommonDAOValues.java
+++ b/src/main/java/org/ndexbio/common/models/dao/orientdb/CommonDAOValues.java
@@ -12,8 +12,8 @@ public interface CommonDAOValues {
 	
 	public static final String DUPLICATED_KEY_FLAG = "duplicated key";
 
-	public static final String DUPLICATED_ACCOUNT_FLAG = "duplicated account name";
-	public static final String DUPLICATED_EMAIL_FLAG = "duplicated email";
+	public static final String DUPLICATED_ACCOUNT_FLAG = "A user with that Account Name has already registered.";
+	public static final String DUPLICATED_EMAIL_FLAG = "A user with that Email has already registered.";
 	
 	public static final String ORIENTDB_DAO_TYPE = "orientdb";
 }

--- a/src/main/java/org/ndexbio/common/models/dao/orientdb/GroupDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/orientdb/GroupDAO.java
@@ -418,9 +418,8 @@ public class GroupDAO extends GroupDocDAO {
 
 		try {
 			getRecordByAccountName(group.getAccountName(), null);
-			logger.info("Group with accountName " + group.getAccountName() + " already exists");
-			throw new DuplicateObjectException(
-					CommonDAOValues.DUPLICATED_ACCOUNT_FLAG);
+			logger.info("Group with accountName " + group.getAccountName() + " already exists.");
+			throw new DuplicateObjectException("Group with Name " + group.getAccountName() + " already exists.");
 		} catch ( ObjectNotFoundException e) {
 		}
 	}


### PR DESCRIPTION
Account Name has already registered. ", and "duplicated email" with  "A
user with that Email has already registered."

Changed the checkForExistingGroup() method to throw
DuplicateObjectException() with the correct message "Group with Name " +
group.getAccountName() + " already exists.".

These changes resolve issue NDEX-203. 