### PR TITLE
setReadOnlyFlag() method now sets RequestsUniqueId attribute so that it

### DIFF
--- a/logback.xml
+++ b/logback.xml
@@ -11,7 +11,8 @@
 			</timeBasedFileNamingAndTriggeringPolicy>
 		</rollingPolicy>
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  -<pattern>%date %level %logger - %msg%n</pattern> -->
+            <pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
 	
@@ -25,18 +26,21 @@
 		<username>support@ndexbio.org</username>
 		<password>ZrdF!nP8</password>
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  <pattern>%date %level %logger - %msg%n</pattern> -->
+			<pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
   	
 	<appender name="STDOUT" level="debug" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  <pattern>%date %level %logger - %msg%n</pattern>  -->
+		    <pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
 	
 	<encoder>
-		<pattern>%date %level %logger - %msg%n</pattern>
+		<!--  <pattern>%date %level %logger - %msg%n</pattern>  -->
+		<pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 	</encoder>
 	
 	<root level="debug">

--- a/src/main/java/org/ndexbio/common/models/dao/orientdb/NetworkDAOTx.java
+++ b/src/main/java/org/ndexbio/common/models/dao/orientdb/NetworkDAOTx.java
@@ -9,6 +9,7 @@ import org.ndexbio.model.object.Status;
 import org.ndexbio.model.object.Task;
 import org.ndexbio.model.object.TaskAttribute;
 import org.ndexbio.model.object.TaskType;
+import org.slf4j.MDC;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
 
@@ -46,7 +47,8 @@ public class NetworkDAOTx extends OrientdbDAO {
 				createCache.setResource(UUIDstr); 
 				createCache.setStatus(Status.QUEUED);
 				createCache.setAttribute(TaskAttribute.readOnlyCommitId, Long.valueOf(newCommitId));
-				
+                createCache.setAttribute("RequestsUniqueId", MDC.get("RequestsUniqueId"));
+                
 				TaskDAO taskDAO = new TaskDAO(this.db);
 				taskDAO.createTask(userAccountName, createCache);
 				db.commit();

--- a/src/main/java/org/ndexbio/task/Configuration.java
+++ b/src/main/java/org/ndexbio/task/Configuration.java
@@ -108,7 +108,7 @@ public class Configuration
     /*
      * This method reads Log-Level configuration parameter from /opt/ndex/conf/ndex.properties 
      * and sets the log level.
-     * In case Log-Level is not found in ndex.properties or value of Log-Level is invalid/unrecognozed,
+     * In case Log-Level is not found in ndex.properties or value of Log-Level is invalid/unrecognized,
      * we set log level to 'info'.
      */
     private void setLogLevel() {

--- a/src/test/resource/logback.xml
+++ b/src/test/resource/logback.xml
@@ -11,7 +11,8 @@
 			</timeBasedFileNamingAndTriggeringPolicy>
 		</rollingPolicy>
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  <pattern>%date %level %logger - %msg%n</pattern> -->
+		    <pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
 	
@@ -25,18 +26,21 @@
 		<username>support@ndexbio.org</username>
 		<password>ZrdF!nP8</password>
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  <pattern>%date %level %logger - %msg%n</pattern> -->
+			<pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
   	
 	<appender name="STDOUT" level="debug" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%date %level %logger - %msg%n</pattern>
+			<!--  <pattern>%date %level %logger - %msg%n</pattern>  -->
+			<pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 		</encoder>
 	</appender>
 	
 	<encoder>
-		<pattern>%date %level %logger - %msg%n</pattern>
+		<!-- <pattern>%date %level %logger - %msg%n</pattern> -->
+		<pattern>[%date]&#9;[%level]&#9;[%X{ClientIP}]&#9;[%X{RequestsUniqueId}]&#9;[%X{UserName}]&#9;%msg&#9;[%C{0}.%method]%n</pattern>
 	</encoder>
 	
 	<root level="debug">


### PR DESCRIPTION
could be used by ClientTaskProcessor to stamp log entries;

ClientTaskProcessor is modified to use slf4j Logging framework instead
of java.util.logging.Logger.
Run() method of ClientTaskProcessor now uses RequestsUniqueId to stamp
log entries.